### PR TITLE
Allow speakers to save papers as draft

### DIFF
--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -1,0 +1,3 @@
+@import "bootstrap-sprockets"
+@import "bootstrap"
+@import "overrides"

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,2 +1,0 @@
-@import "bootstrap-sprockets";
-@import "bootstrap";

--- a/app/assets/stylesheets/overrides.sass
+++ b/app/assets/stylesheets/overrides.sass
@@ -1,0 +1,2 @@
+.label
+  text-transform: capitalize

--- a/app/controllers/my/papers_controller.rb
+++ b/app/controllers/my/papers_controller.rb
@@ -33,7 +33,11 @@ class My::PapersController < ApplicationController
   private
 
   def paper_params
-    params.require(:paper).permit(:title, :abstract)
+    params.require(:paper).permit(:title, :abstract).merge(status: paper_status)
+  end
+
+  def paper_status
+    params[:draft] ? :draft : :submitted
   end
 
   def find_paper

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal:true
 
 class Paper < ApplicationRecord
+  with_options unless: :draft? do
+    validates :abstract, presence: true
+  end
   validates :title, presence: true
-  validates :abstract, presence: true
   validates :status, presence: true
 
   belongs_to :user, inverse_of: :papers
 
-  enum status: [:drafted, :submitted, :accepted, :rejected, :withdrawn].freeze
+  enum status: [:draft, :submitted, :accepted, :rejected, :withdrawn].freeze
 end

--- a/app/views/my/papers/new.html.erb
+++ b/app/views/my/papers/new.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <div class="row">
-    <div class="col-xs-12">
+    <div class="col-xs-12 col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-3">
 
       <h1>Paper submission</h1>
 
@@ -16,8 +16,9 @@
           <%= f.text_area :abstract, class: "form-control" %>
         </div>
 
-        <div class="form-controls">
-          <%= f.submit "Submit for review", class: "btn btn-primary" %>
+        <div class="form-controls text-right">
+          <%= f.submit "Save as draft", name: "draft", class: "btn btn-default" %>
+          <%= f.submit "Submit", name: "submit", class: "btn btn-primary" %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
This change allows speakers to save their papers as draft. This is implemented as a simple `enum` status.