### PR TITLE
Fix logo breaking on Heroku

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,7 +1,7 @@
 <div class="container full-page">
   <div class="row">
     <div class="col-xs-12 text-center">
-      <%= image_tag "logo-vertical", class: "logo" %>
+      <%= image_tag "logo-vertical.png", class: "logo" %>
 
       <div class="intro">
         <span>Two Days • Single Track</span>


### PR DESCRIPTION
The logo wasn't showing up on Heroku because of an incomplete asset path. This change fixes that.