### PR TITLE
Add outline to papers

### DIFF
--- a/app/assets/stylesheets/overrides.sass
+++ b/app/assets/stylesheets/overrides.sass
@@ -1,2 +1,9 @@
 .label
   text-transform: capitalize
+
+label + small
+  display: block
+  margin-bottom: 8px
+
+textarea.form-control
+  height: 200px

--- a/app/controllers/my/papers_controller.rb
+++ b/app/controllers/my/papers_controller.rb
@@ -52,7 +52,7 @@ class My::PapersController < ApplicationController
   private
 
   def paper_params
-    params.require(:paper).permit(:speaker_slot, :title, :abstract).merge(status: paper_status)
+    params.require(:paper).permit(:speaker_slot, :title, :abstract, :outline).merge(status: paper_status)
   end
 
   def paper_status

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -3,6 +3,7 @@
 class Paper < ApplicationRecord
   with_options unless: :draft? do
     validates :abstract, presence: true
+    validates :outline,  presence: true
   end
   validates :title,        presence: true
   validates :status,       presence: true

--- a/app/views/my/papers/edit.html.erb
+++ b/app/views/my/papers/edit.html.erb
@@ -24,7 +24,14 @@
 
         <div class="form-group">
           <%= f.label :abstract %>
+          <small>(We will put this on the website if your talk is selected.)</small>
           <%= f.text_area :abstract, class: "form-control" %>
+        </div>
+
+        <div class="form-group">
+          <%= f.label :outline %>
+          <small>(This can only be seen by the review board and organizing committee.)</small>
+          <%= f.text_area :outline, class: "form-control" %>
         </div>
 
         <div class="form-controls text-right">

--- a/app/views/my/papers/new.html.erb
+++ b/app/views/my/papers/new.html.erb
@@ -25,7 +25,14 @@
 
         <div class="form-group">
           <%= f.label :abstract %>
+          <small>(We will put this on the website if your talk is selected.)</small>
           <%= f.text_area :abstract, class: "form-control" %>
+        </div>
+
+        <div class="form-group">
+          <%= f.label :outline %>
+          <small>(This can only be seen by the review board and organizing committee.)</small>
+          <%= f.text_area :outline, class: "form-control" %>
         </div>
 
         <div class="form-controls text-right">

--- a/app/views/my/papers/show.html.erb
+++ b/app/views/my/papers/show.html.erb
@@ -6,7 +6,11 @@
       <span class="label label-primary"><%= @paper.status %></span>
       <span class="label label-primary"><%= @paper.speaker_slot %></span>
 
+      <h2>Abstract</h2>
       <p><%= @paper.abstract %></p>
+
+      <h2>Outline</h2>
+      <p><%= @paper.outline %></p>
 
       <div class="text-right">
         <% if @paper.editable? %>

--- a/db/migrate/20161205095042_add_outline_to_paper.rb
+++ b/db/migrate/20161205095042_add_outline_to_paper.rb
@@ -1,0 +1,5 @@
+class AddOutlineToPaper < ActiveRecord::Migration[5.0]
+  def change
+    add_column :papers, :outline, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161122071159) do
+ActiveRecord::Schema.define(version: 20161205095042) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 20161122071159) do
     t.integer "status",       default: 1, null: false
     t.integer "user_id"
     t.integer "speaker_slot", default: 1, null: false
+    t.text    "outline"
     t.index ["user_id"], name: "index_papers_on_user_id", using: :btree
   end
 

--- a/spec/factories/paper.rb
+++ b/spec/factories/paper.rb
@@ -6,6 +6,7 @@ FactoryGirl.define do
 
     title        "A New Hope"
     abstract     "A long time ago in a galaxy far, far away ..."
+    outline      "Possibly the best paper ever submitted."
 
     status       :submitted
     speaker_slot :regular

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Paper, type: :model do
 
   it { is_expected.to validate_presence_of(:title) }
   it { is_expected.to validate_presence_of(:abstract) }
+  it { is_expected.to validate_presence_of(:outline) }
   it { is_expected.to validate_presence_of(:status) }
   it { is_expected.to validate_presence_of(:speaker_slot) }
 


### PR DESCRIPTION
This change adds an outline to papers, which is intended to be seen only by the review committee and organizing committee.

Here, the speaker can make a more compelling case for why their talk should be included in the conference.

<img width="981" alt="screen shot 2016-12-05 at 18 02 49" src="https://cloud.githubusercontent.com/assets/5259935/20881137/d77a2b9c-bb15-11e6-9c0a-a3e5ddf50136.png">
