### PR TITLE
Fix new submissions not being reported to Slack

### DIFF
--- a/lib/tasks/slack.rake
+++ b/lib/tasks/slack.rake
@@ -10,15 +10,15 @@ HEADERS = { "Content-Type" => "application/json" }.freeze
 namespace :slack do
   desc "Send an update about the CFP status"
   task send_cfp_status_update: :environment do
-    MESSAGE = "We had %d new CFP submissions in the last week, for a total of %d.".freeze
+    MESSAGE = "We had %d new CFP submissions in the last week, for a total of %d."
 
     # Heroku Scheduler can only run on a daily interval, but we want a weekly
     # report, so do nothing for the other days.
     next unless TODAY.tuesday?
 
-    new_submission_period = (TODAY - 1.week).upto(TODAY)
+    new_submission_period = (TODAY - 1.week)..TODAY
 
-    new_submissions = Paper.submitted.where(updated_at: new_submission_period.to_a).count
+    new_submissions = Paper.submitted.where(updated_at: new_submission_period).count
     all_submissions = Paper.submitted.count
 
     message = format(MESSAGE, new_submissions, all_submissions)


### PR DESCRIPTION
The scheduled job that reports new submissions to Slack on a weekly basis was reporting 0 new submissions, despite there being two.

This was caused by the query checking the `created_at` (a `DateTime`) against an array of `Date`s.

This change fixes that.

---

**Before submitting, check that:**

 - [X] You have written good* commit messages.
 - [X] You have squashed relevant commits together.
 - [X] You have ensured that RuboCop is passing.
 - [X] Your PR relates to one subject.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request
