### PR TITLE
[Fix #37] Use default OAuth scope instead of `user`

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,3 +1,3 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :github, ENV["GITHUB_KEY"], ENV["GITHUB_SECRET"], scope: "user"
+  provider :github, ENV["GITHUB_KEY"], ENV["GITHUB_SECRET"]
 end


### PR DESCRIPTION
As pointed out by one of our CFP submitters, using the `user` scope when authorizing also grants write access to user details.

Clearly we don't need that, so this change sets the scope to default, which gives only read access.

---

**Before submitting, check that:**

 - [X] You have written good* commit messages.
 - [X] You have squashed relevant commits together.
 - [X] You have ensured that RuboCop is passing.
 - [X] Your PR relates to one subject.
 - [X] If it relates to a GitHub issue, you have prefixed the title with `[Fix #n]`.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request
