### PR TITLE
[Fix #34] Add an error message for failed authentication

### DIFF
--- a/app/assets/stylesheets/overrides.sass
+++ b/app/assets/stylesheets/overrides.sass
@@ -1,3 +1,6 @@
+.alert
+  margin-top: 16px
+
 .label
   text-transform: capitalize
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SessionsController < ApplicationController
+  rescue_from ActiveRecord::RecordInvalid, with: :missing_credentials
+
   # GET /auth/github/callback
   def create
     sign_in(auth_user)
@@ -28,5 +30,12 @@ class SessionsController < ApplicationController
 
   def sign_out
     session.delete(:user_id)
+  end
+
+  def missing_credentials
+    message = "Whoops! We need to grab your name and e-mail from GitHub to authenticate you. " \
+              "Please check that they are available from your profile and try agian."
+
+    redirect_to root_path, flash: { error: message }
   end
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -4,14 +4,28 @@ require "rails_helper"
 
 RSpec.describe SessionsController, type: :controller do
   describe "#create" do
-    before do
-      allow(subject).to receive(:auth_user) { FactoryGirl.build(:user) }
+    context "with all credentials present" do
+      before do
+        allow(subject).to receive(:auth_user) { FactoryGirl.build(:user) }
+      end
+
+      before { post :create }
+
+      it { is_expected.to set_session[:user_id] }
+      it { expect(response).to have_http_status(:found) }
     end
 
-    before { post :create }
+    context "with missing credentials" do
+      before do
+        allow(subject).to receive(:auth_user).and_raise(ActiveRecord::RecordInvalid)
+      end
 
-    it { is_expected.to set_session[:user_id] }
-    it { expect(response).to have_http_status(:found) }
+      before { post :create }
+
+      it { is_expected.to set_flash[:error] }
+      it { is_expected.to_not set_session[:user_id] }
+      it { expect(response).to have_http_status(:found) }
+    end
   end
 
   describe "#destroy" do


### PR DESCRIPTION
When attempting to authenticate with a GitHub account that's missing name or e-mail in the profile, the user was met with an unfriendly error page (422). This change makes it so they are instead returned to the auth page, and shown a more informative flash message.

<img width="1160" alt="screen shot 2017-02-01 at 00 56 40" src="https://cloud.githubusercontent.com/assets/5259935/22475435/ea874eb4-e819-11e6-8433-9f4f18fdee79.png">

---

**Before submitting, check that:**

 - [X] You have added (passing) tests for your code.
 - [X] You have written good* commit messages.
 - [X] You have squashed relevant commits together.
 - [X] You have ensured that RuboCop is passing.
 - [X] Your PR relates to one subject.
 - [X] If it relates to a GitHub issue, you have prefixed the title with `[Fix #n]`.

---

**If your change contains views, ensure that:**

 - [X] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request
