### PR TITLE
Show CFP submission deadline and reminder for GitHub credentials

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -9,12 +9,16 @@
         <span>Singapore</span>
       </div>
 
+      <div class="intro">
+        <span>Submission Deadline: Mar 15th 2017</span>
+      </div>
+
       <%= link_to new_my_paper_path, class: "btn btn-lg btn-success" do %>
         <%= fa_icon "github" %>
         Submit a Paper
       <% end %>
-
-      <p class="btn-subtitle">(We'll ask you to authorize through GitHub.)</p>
+      <p class="btn-subtitle">We'll ask you to authorize through GitHub.</p>
+      <p class="btn-subtitle">Please set your name and email to public visibility in your GitHub Settings.</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Add CFP submission deadline to landing page

Also remind users to ensure their GitHub account name and email
are set to public visibility, to reduce drop-offs and
support cases due to failed GitHub authorization

![screen shot 2017-02-21 at 11 07 58 pm](https://cloud.githubusercontent.com/assets/761959/23170806/8eaa0c44-f88b-11e6-9ba8-c9ff197d2820.png)
