### PR TITLE
Automatically disable CFP at closing time

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,4 +21,9 @@ class ApplicationController < ActionController::Base
     User.find_by(id: session[:user_id])
   end
   helper_method :current_user
+
+  def current_conference
+    Conference.latest
+  end
+  helper_method :current_conference
 end

--- a/app/controllers/my/papers_controller.rb
+++ b/app/controllers/my/papers_controller.rb
@@ -5,6 +5,7 @@ class My::PapersController < ApplicationController
 
   before_action :authenticate!
   before_action :authorize_speaker!
+  before_action :check_closing_time!, only: [:new, :create, :edit, :update]
 
   # GET /papers
   def index
@@ -68,5 +69,11 @@ class My::PapersController < ApplicationController
 
   def find_paper
     current_user.papers.find(params[:id])
+  end
+
+  def check_closing_time!
+    return if current_conference.cfp_open?
+
+    redirect_to my_papers_path, flash: { notice: "The CFP for this year's RDRC has closed" }
   end
 end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Conference < ApplicationRecord
+  validates :name,          presence: true
+  validates :cfp_closes_at, presence: true
+
+  def self.latest
+    order(cfp_closes_at: :desc).first
+  end
+
+  def cfp_closed?
+    Time.zone.now > cfp_closes_at
+  end
+
+  def cfp_open?
+    !cfp_closed?
+  end
+end

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal:true
+# frozen_string_literal: true
 
 class Paper < ApplicationRecord
   default_scope -> { order(created_at: :desc) }

--- a/app/views/layouts/_speaker_header.html.erb
+++ b/app/views/layouts/_speaker_header.html.erb
@@ -7,7 +7,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <%= link_to "RDRC'17 CFP", my_papers_path, class: "navbar-brand" %>
+      <%= link_to "#{current_conference.name} CFP", my_papers_path, class: "navbar-brand" %>
     </div>
 
     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
@@ -16,7 +16,7 @@
           <li>
             <div class="navbar-form">
               <div class="form-group">
-                <%= link_to "New paper", new_my_paper_path, class: "btn btn-success" %>
+                <%= link_to "New paper", new_my_paper_path, class: "btn btn-success", disabled: current_conference.cfp_closed? %>
               </div>
             </div>
           </li>

--- a/app/views/my/papers/index.html.erb
+++ b/app/views/my/papers/index.html.erb
@@ -11,7 +11,7 @@
         <span class="label label-primary"><%= paper.speaker_slot %></span>
 
         <% if paper.editable? %>
-          <%= link_to "Edit", edit_my_paper_path(paper), class: "btn btn-default"%>
+          <%= link_to "Edit", edit_my_paper_path(paper), class: "btn btn-default", disabled: current_conference.cfp_closed? %>
         <% end %>
 
       <% end %>

--- a/app/views/my/papers/show.html.erb
+++ b/app/views/my/papers/show.html.erb
@@ -14,7 +14,7 @@
 
       <div class="text-right">
         <% if @paper.editable? %>
-          <%= link_to "Edit", edit_my_paper_path(@paper), class: "btn btn-default" %>
+          <%= link_to "Edit", edit_my_paper_path(@paper), class: "btn btn-default", disabled: current_conference.cfp_closed? %>
         <% end %>
       </div>
 

--- a/db/migrate/20170314113845_create_conferences.rb
+++ b/db/migrate/20170314113845_create_conferences.rb
@@ -1,0 +1,10 @@
+class CreateConferences < ActiveRecord::Migration[5.0]
+  def change
+    create_table :conferences do |t|
+      t.string :name, null: false
+      t.datetime :cfp_closes_at, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170303143121) do
+ActiveRecord::Schema.define(version: 20170314113845) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "conferences", force: :cascade do |t|
+    t.string   "name",          null: false
+    t.datetime "cfp_closes_at", null: false
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+  end
 
   create_table "papers", force: :cascade do |t|
     t.string   "title",                        null: false
@@ -26,6 +33,17 @@ ActiveRecord::Schema.define(version: 20170303143121) do
     t.datetime "updated_at"
     t.text     "scrubbed_outline"
     t.index ["user_id"], name: "index_papers_on_user_id", using: :btree
+  end
+
+  create_table "reviews", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "paper_id"
+    t.integer  "score",      null: false
+    t.text     "comments"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["paper_id"], name: "index_reviews_on_paper_id", using: :btree
+    t.index ["user_id"], name: "index_reviews_on_user_id", using: :btree
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/controllers/my/papers_controller_spec.rb
+++ b/spec/controllers/my/papers_controller_spec.rb
@@ -6,10 +6,14 @@ RSpec.describe My::PapersController, type: :controller do
   let(:user) { FactoryGirl.create(:user) }
 
   before do
+    FactoryGirl.create(:conference, cfp_status)
+
     sign_in(user)
   end
 
   describe "#index" do
+    let(:cfp_status) { :open_for_cfp }
+
     before { get :index }
 
     it { expect(response).to have_http_status(:success) }
@@ -18,25 +22,50 @@ RSpec.describe My::PapersController, type: :controller do
   describe "#new" do
     before { get :new }
 
-    it { expect(response).to have_http_status(:success) }
+    context "when CFP is open" do
+      let(:cfp_status) { :open_for_cfp }
+
+      it { expect(response).to have_http_status(:success) }
+    end
+
+    context "when CFP is closed" do
+      let(:cfp_status) { :closed_for_cfp }
+
+      it { is_expected.to set_flash[:notice] }
+      it { expect(response).to have_http_status(:redirect) }
+    end
   end
 
   describe "#create" do
-    context "with valid params" do
-      before { post :create, params: { paper: FactoryGirl.attributes_for(:paper) } }
+    context "when CFP is open" do
+      let(:cfp_status) { :open_for_cfp }
 
-      it { expect(response).to have_http_status(:found) }
+      context "with valid params" do
+        before { post :create, params: { paper: FactoryGirl.attributes_for(:paper) } }
+
+        it { expect(response).to have_http_status(:found) }
+      end
+
+      context "with invalid params" do
+        before { post :create, params: { paper: FactoryGirl.attributes_for(:paper, :invalid) } }
+
+        it { is_expected.to set_flash[:error] }
+        it { expect(response).to have_http_status(:success) }
+      end
     end
 
-    context "with invalid params" do
-      before { post :create, params: { paper: FactoryGirl.attributes_for(:paper, :invalid) } }
+    context "when CFP is closed" do
+      let(:cfp_status) { :closed_for_cfp }
 
-      it { is_expected.to set_flash[:error] }
-      it { expect(response).to have_http_status(:success) }
+      before { post :create, params: { paper: FactoryGirl.attributes_for(:paper) } }
+
+      it { is_expected.to set_flash[:notice] }
+      it { expect(response).to have_http_status(:redirect) }
     end
   end
 
   describe "#show" do
+    let(:cfp_status) { :open_for_cfp }
     let(:paper) { FactoryGirl.create(:paper, user: user) }
 
     before { get :show, params: { id: paper.id } }
@@ -49,23 +78,47 @@ RSpec.describe My::PapersController, type: :controller do
 
     before { get :edit, params: { id: paper.id } }
 
-    it { expect(response).to have_http_status(:success) }
+    context "when CFP is open" do
+      let(:cfp_status) { :open_for_cfp }
+
+      it { expect(response).to have_http_status(:success) }
+    end
+
+    context "when CFP is closed" do
+      let(:cfp_status) { :closed_for_cfp }
+
+      it { is_expected.to set_flash[:notice] }
+      it { expect(response).to have_http_status(:redirect) }
+    end
   end
 
   describe "#update" do
     let(:paper) { FactoryGirl.create(:paper, user: user) }
 
-    context "with valid params" do
-      before { patch :update, params: { id: paper.id, paper: FactoryGirl.attributes_for(:paper) } }
+    context "when CFP is open" do
+      let(:cfp_status) { :open_for_cfp }
 
-      it { expect(response).to have_http_status(:found) }
+      context "with valid params" do
+        before { patch :update, params: { id: paper.id, paper: FactoryGirl.attributes_for(:paper) } }
+
+        it { expect(response).to have_http_status(:found) }
+      end
+
+      context "with invalid params" do
+        before { patch :update, params: { id: paper.id, paper: FactoryGirl.attributes_for(:paper, :invalid) } }
+
+        it { is_expected.to set_flash[:error] }
+        it { expect(response).to have_http_status(:success) }
+      end
     end
 
-    context "with invalid params" do
-      before { patch :update, params: { id: paper.id, paper: FactoryGirl.attributes_for(:paper, :invalid) } }
+    context "when CFP is closed" do
+      let(:cfp_status) { :closed_for_cfp }
 
-      it { is_expected.to set_flash[:error] }
-      it { expect(response).to have_http_status(:success) }
+      before { patch :update, params: { id: paper.id, paper: FactoryGirl.attributes_for(:paper) } }
+
+      it { is_expected.to set_flash[:notice] }
+      it { expect(response).to have_http_status(:redirect) }
     end
   end
 end

--- a/spec/factories/conference.rb
+++ b/spec/factories/conference.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :conference do
+    name "Pod Race"
+
+    cfp_closes_at { 1.day.from_now }
+
+    trait :open_for_cfp do
+      cfp_closes_at { 1.day.from_now }
+    end
+
+    trait :closed_for_cfp do
+      cfp_closes_at { 2.days.ago }
+    end
+  end
+end

--- a/spec/models/conference_spec.rb
+++ b/spec/models/conference_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Conference, type: :model do
+  subject(:paper) { FactoryGirl.build(:conference) }
+
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_presence_of(:cfp_closes_at) }
+
+  describe "#cfp_closed?" do
+    context "when CFP submission date is in the past" do
+      subject(:paper) { FactoryGirl.build(:conference, :closed_for_cfp) }
+
+      it { expect(paper.cfp_closed?).to be_truthy }
+    end
+
+    context "when CFP submission date is in the future" do
+      subject(:paper) { FactoryGirl.build(:conference, :open_for_cfp) }
+
+      it { expect(paper.cfp_closed?).to be_falsey }
+    end
+  end
+
+  describe "#cfp_open?" do
+    context "when CFP submission date is in the past" do
+      subject(:paper) { FactoryGirl.build(:conference, :closed_for_cfp) }
+
+      it { expect(paper.cfp_open?).to be_falsey }
+    end
+
+    context "when CFP submission date is in the future" do
+      subject(:paper) { FactoryGirl.build(:conference, :open_for_cfp) }
+
+      it { expect(paper.cfp_open?).to be_truthy }
+    end
+  end
+end


### PR DESCRIPTION
This change makes it so that it is no longer possible to submit new CFPs after the closing time. Instead the user is met with a notice, saying that CFP is closed. In addition, all buttons to create and edit papers are disabled.

<img width="1161" alt="screen shot 2017-03-14 at 20 10 41" src="https://cloud.githubusercontent.com/assets/5259935/23900146/027e2606-08f3-11e7-8167-280d6d4bb084.png">

---

**Before submitting, check that:**

 - [X] You have added (passing) tests for your code.
 - [X] You have written good* commit messages.
 - [X] You have squashed relevant commits together.
 - [X] You have ensured that RuboCop is passing.
 - [X] Your PR relates to one subject.
 - [ ] If it relates to a GitHub issue, you have prefixed the title with `[Fix #n]`.

---

**If your change contains models, ensure that:**

 - [ ] You have added database seeds for the model.
 - [X] You have added working factories for the model.
 - [X] Your validations have corresponding database constraints.
 - [X] You have checked in the new `schema.rb` after migrating.

---

**If your change contains views, ensure that:**

 - [X] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request
