### PR TITLE
Improve reviewer interface with speaker slot and preserved spacing

### DIFF
--- a/app/views/board/reviews/new.html.erb
+++ b/app/views/board/reviews/new.html.erb
@@ -6,7 +6,7 @@
     </div>
 
     <div class="col-xs-12 col-sm-8">
-      <p><%= @paper.scrubbed_outline %></p>
+      <p><%= simple_format @paper.scrubbed_outline %></p>
     </div>
 
     <%= form_for @review, url: board_paper_reviews_path(@paper), method: :post do |f| %>

--- a/app/views/board/reviews/new.html.erb
+++ b/app/views/board/reviews/new.html.erb
@@ -2,10 +2,11 @@
   <div class="row">
     <div class="col-xs-12 col-sm-8">
       <h1><%= @paper.title %></h1>
+      <span class="label label-primary"><%= @paper.speaker_slot %></span>
     </div>
 
     <div class="col-xs-12 col-sm-8">
-        <p><%= @paper.scrubbed_outline %></p>
+      <p><%= @paper.scrubbed_outline %></p>
     </div>
 
     <%= form_for @review, url: board_paper_reviews_path(@paper), method: :post do |f| %>


### PR DESCRIPTION
This change adds the speaker slot badge to the review page. It also preserves the spacing in the outline.

<img width="375" alt="screen shot 2017-03-23 at 09 55 16" src="https://cloud.githubusercontent.com/assets/5259935/24228390/d66c08ea-0fae-11e7-9bac-4f10e28026d2.png">

---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [X] You have written good* commit messages.
 - [X] You have squashed relevant commits together.
 - [X] You have ensured that RuboCop is passing.
 - [X] Your PR relates to one subject.
 - [ ] If it relates to a GitHub issue, you have prefixed the title with `[Fix #n]`.

---

**If your change contains views, ensure that:**

 - [X] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request
