### PR TITLE
Add view for organizers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,10 @@ class ApplicationController < ActionController::Base
     redirect_to root_path unless current_user.reviewer?
   end
 
+  def authorize_organizer!
+    redirect_to root_path unless current_user.organizer?
+  end
+
   def current_user
     User.find_by(id: session[:user_id])
   end

--- a/app/controllers/organizers/papers_controller.rb
+++ b/app/controllers/organizers/papers_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Organizers::PapersController < ApplicationController
+  layout "cfp"
+
+  before_action :authenticate!
+  before_action :authorize_organizer!
+
+  # GET organizers/papers
+  def index
+    @papers = Paper.scrubbed.includes(:reviews).sort_by { |p| -p.review_score }
+  end
+
+  # GET organizers/paper/:id
+  def show
+    @paper = find_paper
+  end
+
+  private
+
+  def find_paper
+    Paper.find(params[:id])
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -37,6 +37,8 @@ class SessionsController < ApplicationController
       redirect_to cleaners_papers_path
     elsif auth_user.reviewer?
       redirect_to board_papers_path
+    elsif auth_user.organizer?
+      redirect_to organizers_papers_path
     else
       redirect_to my_papers_path
     end

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -28,4 +28,10 @@ class Paper < ApplicationRecord
   def review_by(user)
     reviews.find_by(user: user) || NoReview.new
   end
+
+  def review_score
+    return 0 if reviews.none?
+
+    (reviews.sum(:score) / reviews.count).round(3)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
   has_many :papers,  inverse_of: :user
   has_many :reviews, inverse_of: :user
 
-  enum role: [:speaker, :cleaner, :reviewer, :curator].freeze
+  enum role: [:speaker, :cleaner, :reviewer, :organizer].freeze
 
   def self.create_from_auth!(auth)
     create! do |user|

--- a/app/views/layouts/_organizer_header.html.erb
+++ b/app/views/layouts/_organizer_header.html.erb
@@ -1,0 +1,26 @@
+<nav class="navbar navbar-default">
+  <div class="container">
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <%= link_to "RDRC'17 CFP", organizers_papers_path, class: "navbar-brand" %>
+    </div>
+
+    <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+      <ul class="nav navbar-nav navbar-right">
+        <li>
+          <div class="navbar-form">
+            <div class="form-group">
+              <%= link_to "Papers", organizers_papers_path, class: "btn btn-success" %>
+            </div>
+          </div>
+        </li>
+        <li><%= link_to "Sign out", sign_out_github_path, method: :delete %></li>
+      </ul>
+    </div>
+  </div>
+</nav>

--- a/app/views/layouts/cfp.html.erb
+++ b/app/views/layouts/cfp.html.erb
@@ -16,6 +16,8 @@
       <%= render "layouts/cleaner_header" %>
     <% elsif current_user.reviewer? %>
       <%= render "layouts/board_header" %>
+    <% elsif current_user.organizer? %>
+      <%= render "layouts/organizer_header" %>
     <% else %>
       <%= render "layouts/speaker_header" %>
     <% end %>

--- a/app/views/organizers/papers/index.html.erb
+++ b/app/views/organizers/papers/index.html.erb
@@ -1,0 +1,31 @@
+<div class="container">
+  <div class="row">
+    <div class="col-xs-12">
+      <h1>Reviewed</h1>
+
+      <table class="table table-striped">
+        <thead>
+        <tr>
+          <th>Title</th>
+          <th class="text-center">Review Score</th>
+          <th></th>
+        </tr>
+        </thead>
+
+        <tbody>
+
+        <% @papers.each do |paper| %>
+
+            <tr>
+              <td><%= paper.title %></td>
+              <td class="text-center"><%= number_with_precision paper.review_score, precision: 2 %></td>
+              <td class="text-right"><%= link_to "Show", organizers_paper_path(paper), class: "btn btn-default" %></td>
+            </tr>
+
+        <% end %>
+
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/organizers/papers/show.html.erb
+++ b/app/views/organizers/papers/show.html.erb
@@ -1,0 +1,38 @@
+<div class="container">
+  <div class="row">
+    <div class="col-xs-12 col-sm-8">
+
+      <h1><%= @paper.title %></h1>
+      <span class="label label-primary"><%= @paper.speaker_slot %></span>
+
+      <h2>Abstract</h2>
+      <p><%= simple_format @paper.abstract %></p>
+
+      <h2>Outline</h2>
+      <p><%= simple_format @paper.outline %></p>
+
+    </div>
+
+    <div class="col-xs-12 col-sm-4">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h3 class="panel-title">Review score</h3>
+        </div>
+        <div class="panel-body text-center">
+          <%= @paper.review_score %>
+        </div>
+      </div>
+
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h3 class="panel-title">Review comments</h3>
+        </div>
+        <div class="panel-body">
+          <% @paper.reviews.each do |review| %>
+            <%= review.comments %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,10 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :organizers do
+    resources :papers, only: [:index, :show]
+  end
+
   scope :auth do
     resource :github, only: :none do
       get    :callback, to: "sessions#create"

--- a/spec/controllers/organizers/papers_controller_spec.rb
+++ b/spec/controllers/organizers/papers_controller_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Organizers::PapersController, type: :controller do
+  let(:organizer) { FactoryGirl.create(:user, :organizer) }
+  let(:speaker) { FactoryGirl.create(:user) }
+
+  before do
+    sign_in(organizer)
+  end
+
+  describe "#index" do
+    before { get :index }
+
+    it { expect(response).to have_http_status(:success) }
+  end
+
+  describe "#show" do
+    let(:paper) { FactoryGirl.create(:paper, user: speaker) }
+
+    before { get :show, params: { id: paper.id } }
+
+    it { expect(response).to have_http_status(:success) }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -29,5 +29,9 @@ FactoryGirl.define do
     trait :reviewer do
       role :reviewer
     end
+
+    trait :organizer do
+      role :organizer
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe User, type: :model do
   it { is_expected.to validate_uniqueness_of(:email) }
   it { is_expected.to validate_presence_of(:bio).on(:update) }
 
-  it { is_expected.to define_enum_for(:role).with([:speaker, :cleaner, :reviewer, :curator]) }
+  it { is_expected.to define_enum_for(:role).with([:speaker, :cleaner, :reviewer, :organizer]) }
 
   describe ".create_from_auth" do
     context "with valid attributes" do

--- a/spec/routing/organizers/papers_controller_routing_spec.rb
+++ b/spec/routing/organizers/papers_controller_routing_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Organizers::PapersController, type: :routing do
+  it { expect(get   "/organizers/papers").to   route_to("organizers/papers#index") }
+  it { expect(get   "/organizers/papers/1").to route_to("organizers/papers#show", id: "1") }
+end


### PR DESCRIPTION
This change adds a simple view for organizers to explore the papers, and includes an average review score as well as volatility.

**Index view:**

<img width="1155" alt="screen shot 2017-04-15 at 14 49 04" src="https://cloud.githubusercontent.com/assets/5259935/25061511/b51ec954-21ea-11e7-942a-43562e0e55dc.png">

**Show view:**

<img width="1158" alt="screen shot 2017-04-15 at 14 48 00" src="https://cloud.githubusercontent.com/assets/5259935/25061502/9f095094-21ea-11e7-8c91-92ed83b80d01.png">

---

**Before submitting, check that:**

 - [X] You have added (passing) tests for your code.
 - [X] You have written good* commit messages.
 - [X] You have squashed relevant commits together.
 - [X] You have ensured that RuboCop is passing.
 - [X] Your PR relates to one subject.
 - [ ] If it relates to a GitHub issue, you have prefixed the title with `[Fix #n]`.

---

**If your change contains views, ensure that:**

 - [X] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request
