### PR TITLE
Add speaker slot and -name to organizer view

### DIFF
--- a/app/views/organizers/papers/index.html.erb
+++ b/app/views/organizers/papers/index.html.erb
@@ -7,6 +7,7 @@
         <thead>
         <tr>
           <th>Title</th>
+          <th>Speaker</th>
           <th class="text-center">Review Score</th>
           <th></th>
         </tr>
@@ -17,7 +18,11 @@
         <% @papers.each do |paper| %>
 
             <tr>
-              <td><%= paper.title %></td>
+              <td>
+                <%= paper.title %>
+                <span class="label label-primary"><%= paper.speaker_slot %></span>
+              </td>
+              <td><%= paper.user.name %></td>
               <td class="text-center"><%= number_with_precision paper.review_score, precision: 2 %></td>
               <td class="text-right"><%= link_to "Show", organizers_paper_path(paper), class: "btn btn-default" %></td>
             </tr>

--- a/app/views/organizers/papers/show.html.erb
+++ b/app/views/organizers/papers/show.html.erb
@@ -3,6 +3,7 @@
     <div class="col-xs-12 col-sm-8">
 
       <h1><%= @paper.title %></h1>
+      <p>By: <%= @paper.user.name %></p>
       <span class="label label-primary"><%= @paper.speaker_slot %></span>
 
       <h2>Abstract</h2>


### PR DESCRIPTION
This change adds more information into the organizer view.

**Index view:**

<img width="1151" alt="screen shot 2017-04-15 at 15 16 23" src="https://cloud.githubusercontent.com/assets/5259935/25061689/8fab2556-21ee-11e7-9929-1fc70e8451ee.png">

**Show view:**

<img width="1160" alt="screen shot 2017-04-15 at 15 16 28" src="https://cloud.githubusercontent.com/assets/5259935/25061690/913afe28-21ee-11e7-9a73-33c637813359.png">

---

**Before submitting, check that:**

 - [ ] You have added (passing) tests for your code.
 - [X] You have written good* commit messages.
 - [X] You have squashed relevant commits together.
 - [X] You have ensured that RuboCop is passing.
 - [X] Your PR relates to one subject.
 - [ ] If it relates to a GitHub issue, you have prefixed the title with `[Fix #n]`.

---

**If your change contains views, ensure that:**

 - [X] You have included a screenshot of the new view.

---

*If you do not know what makes a good commit message, or why it
is important, please refer to these resources: [1][1], [2][2], [3][3].

[1]: https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
[2]: http://chris.beams.io/posts/git-commit/
[3]: https://github.com/blog/1943-how-to-write-the-perfect-pull-request
