### PR TITLE
add link to my paper

### DIFF
--- a/app/views/my/papers/index.html.erb
+++ b/app/views/my/papers/index.html.erb
@@ -6,7 +6,7 @@
 
       <% @papers.each do |paper| %>
 
-        <h2><%= paper.title %></h2>
+        <h2><%= link_to paper.title, my_paper_path(paper) %></h2>
         <span class="label label-primary"><%= paper.status %></span>
         <span class="label label-primary"><%= paper.speaker_slot %></span>
 


### PR DESCRIPTION
Add link to my paper at `/my/papers` page.
CFP submitters can not show their paper's details after CFP was closed.
So this PR solve this.

Thank you in advance.